### PR TITLE
Update Makefile to bonnell arch

### DIFF
--- a/arch/x86/Makefile
+++ b/arch/x86/Makefile
@@ -55,8 +55,8 @@ else
 
         cflags-$(CONFIG_MCORE2) += \
                 $(call cc-option,-march=core2,$(call cc-option,-mtune=generic))
-	cflags-$(CONFIG_MATOM) += $(call cc-option,-march=atom) \
-		$(call cc-option,-mtune=atom,$(call cc-option,-mtune=generic))
+	ccflags-$(CONFIG_MATOM) += $(call cc-option,-march=bonnell) \
+		$(call cc-option,-mtune=bonnell,$(call cc-option,-mtune=generic))
         cflags-$(CONFIG_GENERIC_CPU) += $(call cc-option,-mtune=generic)
         KBUILD_CFLAGS += $(cflags-y)
 


### PR DESCRIPTION
According the Graysky2 GCC Patch: https://github.com/graysky2/kernel_gcc_patch/blob/master/enable_additional_cpu_optimizations_for_gcc_v4.9%2B_kernel_v3.15%2B.patch
Enable specific flags to Intel Atom based in Saltwell architeture. Change the cflags in the entire ROM could improve the performance.
Works with GCC >=4.9
